### PR TITLE
Module 2: tensor_functions: Expand the backward result of Add

### DIFF
--- a/.github/workflows/minitorch.yml
+++ b/.github/workflows/minitorch.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        flake8 --ignore "N801, E203, E266, E501, W503, F812, F401, F841, E741, N803, N802, N806" minitorch/ tests/ project/
+        flake8 --ignore "N801, E203, E266, E501, W503, F812, F401, F841, E741, N803, N802, N806, DAR" minitorch/ tests/ project/
     - name: Test with pytest
       run: |
         echo "Module 0"

--- a/minitorch/tensor_functions.py
+++ b/minitorch/tensor_functions.py
@@ -88,11 +88,13 @@ def make_tensor_backend(tensor_ops, is_cuda=False):
         class Add(Function):
             @staticmethod
             def forward(ctx, t1, t2):
+                ctx.save_for_backward(t1, t2)
                 return add_zip(t1, t2)
 
             @staticmethod
             def backward(ctx, grad_output):
-                return grad_output, grad_output
+                t1, t2 = ctx.saved_values
+                return t1.expand(grad_output), t2.expand(grad_output)
 
         class Mul(Function):
             @staticmethod


### PR DESCRIPTION
## Description

The provided `Add` class does not pass the tests since we need to `expand()` `grad_output` to handle broadcasting.

This PR adds `expand()` to the Add function.

(If it was actually intentional for `expand()` to not be used, then we should instead add TODOs in `Add` to notify the students that `Add` needs to be fixed. We should then also mention `expand()` in the docs—it's really not obvious that students need to use this `expand()` function that was not mentioned anywhere.)