### PR TITLE
Modules  1: Update backprop_step's return type comment

### DIFF
--- a/.github/workflows/minitorch.yml
+++ b/.github/workflows/minitorch.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        flake8 --ignore "N801, E203, E266, E501, W503, F812, F401, F841, E741, N803, N802, N806" minitorch/ tests/ project/
+        flake8 --ignore "N801, E203, E266, E501, W503, F812, F401, F841, E741, N803, N802, N806, DAR" minitorch/ tests/ project/
     - name: Test with pytest
       run: |
         echo "Module 0"

--- a/minitorch/autodiff.py
+++ b/minitorch/autodiff.py
@@ -188,7 +188,7 @@ class History:
             d_output : a derivative with respect to this variable
 
         Returns:
-            list of numbers : a derivative with respect to `inputs`
+            list of (`Variable`, number) : derivatives with respect to `inputs`
         """
         # TODO: Implement for Task 1.4.
         raise NotImplementedError('Need to implement for Task 1.4')


### PR DESCRIPTION
Changes:
- In `autodiff.py`,  `backprop_step` should return a dictionary mapping parameters names to Parameters, like `chain_rule()` does.