### PR TITLE
Fix is_constant in Scalar.

### DIFF
--- a/minitorch/scalar_functions.py
+++ b/minitorch/scalar_functions.py
@@ -54,6 +54,7 @@ class ScalarFunction:
                 raw_vals.append(v.data)
             else:
                 scalars.append(minitorch.scalar.Scalar(v))
+                scalars[-1].history = None
                 raw_vals.append(v)
 
         # Create the context.


### PR DESCRIPTION
Since is_constant checks wheter history is None to tell if the scalar is constant. When a constant is used in a function, it should be constructed as a scalar without history